### PR TITLE
fix: change cam2 input to /dev/video4

### DIFF
--- a/jetsonNano/ros2_ws/src/usb_cam/config/params_1.yaml
+++ b/jetsonNano/ros2_ws/src/usb_cam/config/params_1.yaml
@@ -1,7 +1,7 @@
 /**:
     ros__parameters:
       video_device: "/dev/video0"
-      framerate: 10.0
+      framerate: 5.0
       io_method: "mmap"
       frame_id: "camera"
       pixel_format: "yuyv"  # see usb_cam/supported_formats for list of supported formats

--- a/jetsonNano/ros2_ws/src/usb_cam/config/params_2.yaml
+++ b/jetsonNano/ros2_ws/src/usb_cam/config/params_2.yaml
@@ -1,7 +1,7 @@
 /**:
     ros__parameters:
-      video_device: "/dev/video2"
-      framerate: 10.0
+      video_device: "/dev/video4"
+      framerate: 5.0
       io_method: "mmap"
       frame_id: "camera2"
       pixel_format: "yuyv"


### PR DESCRIPTION
This pull request updates the configuration for two USB cameras in the ROS2 workspace. The main changes involve reducing the framerate and updating the device path for one of the cameras.

Camera configuration updates:

* Lowered the `framerate` from 10.0 to 5.0 in both `params_1.yaml` and `params_2.yaml` to reduce resource usage or adapt to new requirements. [[1]](diffhunk://#diff-726c3a8a39b12fc26683af913ac91023cc454bb12e7860e04c022c6ed317caa9L4-R4) [[2]](diffhunk://#diff-a9cae50fd8c28b41c870a4cc1ad14c22ab71072dcc7fa93b089801fe02708974L3-R4)
* Changed the `video_device` path from `/dev/video2` to `/dev/video4` in `params_2.yaml`, hardware update.