### PR TITLE
feat: add foxglove server starting

### DIFF
--- a/jetsonNano/ros2_ws/src/geicar_start_jetson/launch/geicar.jetson.launch.py
+++ b/jetsonNano/ros2_ws/src/geicar_start_jetson/launch/geicar.jetson.launch.py
@@ -156,6 +156,13 @@ def generate_launch_description():
         }.items(),
     )
 
+    foxglove_server = Node(
+        package='foxglove_bridge',
+        executable='foxglove_bridge',
+        emulate_tty=True,
+        parameters=[{'use_sim_time': LaunchConfiguration('use_sim_time')}],
+    )
+
     # --- Add Actions to Launch Description ---
 
     # Add the argument declarations
@@ -175,5 +182,6 @@ def generate_launch_description():
     ld.add_action(rf2o_laser_odometry_node)
     #ld.add_action(robot_localization_node)
     ld.add_action(slam_toolbox_launch_file)
+    ld.add_action(foxglove_server)
 
     return ld


### PR DESCRIPTION
This pull request adds support for Foxglove Bridge to the Jetson Nano launch configuration, enhancing visualization and debugging capabilities for ROS 2 data streams. The main change is the inclusion of the Foxglove Bridge node in the launch file.

**Foxglove Bridge Integration:**

* Added a new `foxglove_server` node using the `foxglove_bridge` package and executable, with `use_sim_time` parameter support. (`jetsonNano/ros2_ws/src/geicar_start_jetson/launch/geicar.jetson.launch.py`)
* Included the `foxglove_server` node in the launch description actions so it starts with the rest of the system. (`jetsonNano/ros2_ws/src/geicar_start_jetson/launch/geicar.jetson.launch.py`)