### PR TITLE
fix: fix thread not joining correclly causing a impossible shutdown o…

### DIFF
--- a/jetsonNano/ros2_ws/src/network_hmi/CMakeLists.txt
+++ b/jetsonNano/ros2_ws/src/network_hmi/CMakeLists.txt
@@ -12,6 +12,9 @@ find_package(rclcpp REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(interfaces REQUIRED)
+find_package(tf2 REQUIRED)
+find_package(tf2_ros REQUIRED)
+find_package(tf2_geometry_msgs REQUIRED)
 find_package(nlohmann_json REQUIRED)
 find_package(cv_bridge REQUIRED)
 find_package(PkgConfig REQUIRED)
@@ -108,6 +111,9 @@ ament_target_dependencies(network_hmi_lib
   rclcpp
   interfaces
   nav_msgs
+  tf2
+  tf2_ros
+  tf2_geometry_msgs
   sensor_msgs
   cv_bridge
 )

--- a/jetsonNano/ros2_ws/src/network_hmi/include/network_hmi/tcp_udp_bridge_node.hpp
+++ b/jetsonNano/ros2_ws/src/network_hmi/include/network_hmi/tcp_udp_bridge_node.hpp
@@ -4,6 +4,9 @@
 #include <nav_msgs/msg/odometry.hpp>
 #include <sensor_msgs/msg/compressed_image.hpp>
 #include <nav_msgs/msg/occupancy_grid.hpp>
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_listener.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #include "interfaces/msg/joystick_order.hpp"
 #include "interfaces/msg/general_data.hpp"
 #include "interfaces/msg/control.hpp"
@@ -58,6 +61,11 @@ private:
     std::unique_ptr<UdpDataSender> udp_sender_;
     std::unique_ptr<UdpDataReceiver> udp_receiver_;
     std::unique_ptr<TcpControlServer> tcp_server_;
+
+    // --- TF ---
+    std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
+    std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
+
 
     // --- Image fragmentation constants ---
     static constexpr int IMAGE_PACKET_PAYLOAD_SIZE = 1400; 

--- a/jetsonNano/ros2_ws/src/network_hmi/package.xml
+++ b/jetsonNano/ros2_ws/src/network_hmi/package.xml
@@ -14,6 +14,9 @@
   <depend>rclcpp</depend>
   <depend>interfaces</depend>
   <depend>nav_msgs</depend>
+  <depend>tf2</depend>
+  <depend>tf2_ros</depend>
+  <depend>tf2_geometry_msgs</depend>
 
   <!-- Test dependencies -->
   <test_depend>ament_lint_auto</test_depend>

--- a/jetsonNano/ros2_ws/src/network_hmi/src/tcp_control_server.cpp
+++ b/jetsonNano/ros2_ws/src/network_hmi/src/tcp_control_server.cpp
@@ -36,14 +36,39 @@ void TcpControlServer::start()
 
 void TcpControlServer::stop()
 {
+    RCLCPP_INFO(logger_, "TcpControlServer::stop() entry");
     running_ = false;
+
+    // Close the listening socket first to unblock accept()
     if (server_fd_ != -1) {
-        close(server_fd_); // This unblocks accept()
+        // First try shutdown to interrupt accept/listen
+        shutdown(server_fd_, SHUT_RDWR);
+        close(server_fd_); // This should unblock accept()
         server_fd_ = -1;
     }
+
+    // Make a local copy of client sockets while holding the mutex,
+    // then release the lock and shutdown/close each socket to
+    // promptly unblock client session threads.
+    std::vector<int> client_sockets;
+    {
+        std::lock_guard<std::mutex> lock(sessions_mutex_);
+        for (auto &s : client_sessions_) {
+            if (s) client_sockets.push_back(s->get_socket());
+        }
+    }
+
+    for (int sock : client_sockets) {
+        if (sock != -1) {
+            shutdown(sock, SHUT_RDWR);
+            close(sock);
+        }
+    }
+
     if (thread_.joinable()) {
         thread_.join();
     }
+    RCLCPP_INFO(logger_, "TcpControlServer::stop() exit");
 }
 
 void TcpControlServer::accept_loop()
@@ -77,10 +102,14 @@ void TcpControlServer::accept_loop()
     RCLCPP_INFO(logger_, "TCP Server listening on port %d", port_);
 
     while (running_) {
+        RCLCPP_DEBUG(logger_, "accept_loop: waiting for new connection (server_fd=%d)", server_fd_);
         int new_socket = accept(server_fd_, (struct sockaddr *)&address, (socklen_t *)&addrlen);
         if (new_socket < 0) {
+            int err = errno;
             if (running_) {
-                RCLCPP_WARN(logger_, "TCP accept error: %s", strerror(errno));
+                RCLCPP_WARN(logger_, "TCP accept error: %s", strerror(err));
+            } else {
+                RCLCPP_DEBUG(logger_, "accept returned error %s after running_ set false", strerror(err));
             }
             continue;
         }

--- a/jetsonNano/ros2_ws/src/network_hmi/src/tcp_control_server.cpp
+++ b/jetsonNano/ros2_ws/src/network_hmi/src/tcp_control_server.cpp
@@ -25,7 +25,13 @@ TcpControlServer::TcpControlServer(
 
 TcpControlServer::~TcpControlServer()
 {
-    stop();
+    try {
+        stop();
+    } catch (const std::exception & e) {
+        RCLCPP_ERROR(logger_, "Exception in ~TcpControlServer: %s", e.what());
+    } catch (...) {
+        RCLCPP_ERROR(logger_, "Unknown exception in ~TcpControlServer");
+    }
 }
 
 void TcpControlServer::start()
@@ -36,7 +42,7 @@ void TcpControlServer::start()
 
 void TcpControlServer::stop()
 {
-    RCLCPP_INFO(logger_, "TcpControlServer::stop() entry");
+    //RCLCPP_INFO(logger_, "TcpControlServer::stop() entry");
     running_ = false;
 
     // Close the listening socket first to unblock accept()
@@ -68,7 +74,7 @@ void TcpControlServer::stop()
     if (thread_.joinable()) {
         thread_.join();
     }
-    RCLCPP_INFO(logger_, "TcpControlServer::stop() exit");
+    //RCLCPP_INFO(logger_, "TcpControlServer::stop() exit");
 }
 
 void TcpControlServer::accept_loop()

--- a/jetsonNano/ros2_ws/src/network_hmi/src/tcp_udp_bridge_node.cpp
+++ b/jetsonNano/ros2_ws/src/network_hmi/src/tcp_udp_bridge_node.cpp
@@ -4,6 +4,11 @@
 #include <sensor_msgs/image_encodings.hpp>
 #include <cv_bridge/cv_bridge.h>
 
+#include <cmath>
+#include <algorithm>
+#include <tf2/LinearMath/Quaternion.h>
+#include <tf2/LinearMath/Matrix3x3.h>
+
 #include <nlohmann/json.hpp>
 #include <arpa/inet.h> // For htonl, htons
 #include <cstring> // For memcpy
@@ -42,6 +47,10 @@ TcpUdpBridgeNode::TcpUdpBridgeNode()
     vehicle_state_ = std::make_shared<SharedVehicleState>();
     client_info_ = std::make_shared<SharedClientInfo>(this->get_logger());
     udp_sender_ = std::make_unique<UdpDataSender>();
+
+    // --- TF Init ---
+    tf_buffer_ = std::make_shared<tf2_ros::Buffer>(this->get_clock());
+    tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
     
     // The receiver needs the node to create a publisher
     udp_receiver_ = std::make_unique<UdpDataReceiver>(
@@ -181,43 +190,132 @@ void TcpUdpBridgeNode::map_callback(const nav_msgs::msg::OccupancyGrid::SharedPt
         return; // No client connected or client didn't want data
     }
 
-    uint32_t w = msg->info.width;
-    uint32_t h = msg->info.height;
+    // 1. Get Car Position from TF
+    geometry_msgs::msg::TransformStamped transform;
+    try {
+        transform = tf_buffer_->lookupTransform("map", "base_link", tf2::TimePointZero);
+    } catch (tf2::TransformException &ex) {
+        RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 1000, "Could not transform map to base_link: %s", ex.what());
+        return;
+    }
+
+    double car_x = transform.transform.translation.x;
+    double car_y = transform.transform.translation.y;
     
-    // Downsample map if too large
-    float x_scale = 1.0f;
-    float y_scale = 1.0f;
-    if (w > MAP_SIZE_LIMIT) {
-        x_scale = static_cast<float>(w) / MAP_SIZE_LIMIT;
-    }
-    if (h > MAP_SIZE_LIMIT) {
-        y_scale = static_cast<float>(h) / MAP_SIZE_LIMIT;
-    }
-    float scale = std::max(x_scale, y_scale);
-    uint32_t r_w = static_cast<uint32_t>(w / scale);
-    uint32_t r_h = static_cast<uint32_t>(h / scale);
-    std::vector<int8_t> r_map(r_w * r_h);
-    for (uint32_t y = 0; y < r_h; ++y) {
-        for (uint32_t x = 0; x < r_w; ++x) {
-            uint32_t orig_x = static_cast<uint32_t>(x * scale);
-            uint32_t orig_y = static_cast<uint32_t>(y * scale);
-            r_map[y * r_w + x] = msg->data[orig_y * w + orig_x];
+    // Get car yaw
+    tf2::Quaternion q(
+        transform.transform.rotation.x,
+        transform.transform.rotation.y,
+        transform.transform.rotation.z,
+        transform.transform.rotation.w);
+    tf2::Matrix3x3 m(q);
+    double roll, pitch, car_yaw;
+    m.getRPY(roll, pitch, car_yaw);
+
+    // 2. Define Local Map Parameters
+    // We want a fixed size output, e.g., 60x60 pixels
+    const int OUTPUT_SIZE = 60; 
+    // We want to cover a certain area, e.g., 12m x 12m -> 0.2m/pixel
+    const double OUTPUT_RES = 0.1; 
+    
+    std::vector<int8_t> rotated_map(OUTPUT_SIZE * OUTPUT_SIZE, -1); // Initialize with unknown
+
+    int width = msg->info.width;
+    int height = msg->info.height;
+    double map_res = msg->info.resolution;
+    double map_origin_x = msg->info.origin.position.x;
+    double map_origin_y = msg->info.origin.position.y;
+
+    double cos_yaw = cos(car_yaw);
+    double sin_yaw = sin(car_yaw);
+
+    // 3. Iterate over output pixels and sample from original map
+    for (int y = 0; y < OUTPUT_SIZE; ++y) {
+        for (int x = 0; x < OUTPUT_SIZE; ++x) {
+            // Convert to local coordinates (center is 0,0)
+            // x corresponds to forward (up in image), y to left
+            // Image coordinates: u (col) -> right (-y local), v (row) -> down (-x local)?
+            // Usually map visualization: x right, y up.
+            // Let's verify standard: 
+            // - Car frame: x forward, y left.
+            // - We want Image: x (col) from left to right, y (row) from top to bottom.
+            // - So Top-Center of image should be +x (forward).
+            // - Center of image is (OUTPUT_SIZE/2, OUTPUT_SIZE/2).
+            
+            // Let's map:
+            // img_x (0..60) -> local_y (left)
+            // img_y (0..60) -> local_x (forward)
+            
+            // Standard image convention: x is right, y is down.
+            // Car frame: x is forward, y is left.
+            // We want car forward to be UP in the image.
+            // So Image UP (decreasing row/y) = Car X (forward)
+            // Image RIGHT (increasing col/x) = Car -Y (right)
+            
+
+
+            // Map image coords to car coords (meters)
+            // row y (0 at top) corresponds to +X (forward)
+            // Actually, usually:
+            // Pixel (x,y): 
+            // x (col): right direction. Car frame: -Y (right).
+            // y (row): down direction. Car frame: -X (backward).
+            // So pixel (0,0) is Front-Left relative to car? No.
+            // Let's stick to standard map orientation: North up.
+            // Here "Car Up" (Forward) should be Image Up.
+            
+            // local_x = - (img_cy) * RES (Up is +x)
+            // local_y = - (img_cx) * RES (Right is -y)
+            
+            // Let's refine: 
+            // Image center (30,30) is car (0,0).
+            // Pixel (30, 0) [Top Middle] -> should be Forward (+X). 
+            // dy = 0 - 30 = -30. So -dy * RES = +X. -> X = -(y - 30) * RES
+            // Pixel (60, 30) [Right Middle] -> should be Right (-Y).
+            // dx = 60 - 30 = +30. So dx * RES = -Y. -> Y = -(x - 30) * RES
+            
+            double local_x = -(y - OUTPUT_SIZE / 2.0) * OUTPUT_RES;
+            double local_y = -(x - OUTPUT_SIZE / 2.0) * OUTPUT_RES;
+
+            // Rotate to Map Frame
+            // global_x = car_x + local_x * cos - local_y * sin
+            // global_y = car_y + local_x * sin + local_y * cos
+            double global_x = car_x + (local_x * cos_yaw - local_y * sin_yaw);
+            double global_y = car_y + (local_x * sin_yaw + local_y * cos_yaw);
+
+            // Convert to Map Grid Indices
+            int gx = static_cast<int>((global_x - map_origin_x) / map_res);
+            int gy = static_cast<int>((global_y - map_origin_y) / map_res);
+
+            // Check bounds
+            if (gx >= 0 && gx < width && gy >= 0 && gy < height) {
+                rotated_map[y * OUTPUT_SIZE + x] = msg->data[gy * width + gx];
+            } else {
+                rotated_map[y * OUTPUT_SIZE + x] = -1; // Unknown
+            }
         }
     }
 
     json map_info_msg = {
         {"type", "occupancy_grid"},
-        {"width", r_w},
-        {"height", r_h},
-        {"resolution", msg->info.resolution * scale},
-        {"origin_position_x", msg->info.origin.position.x},
-        {"origin_position_y", msg->info.origin.position.y},
-        {"origin_position_z", msg->info.origin.position.z},
-        {"origin_orientation_x", msg->info.origin.orientation.x},
-        {"origin_orientation_y", msg->info.origin.orientation.y},
-        {"origin_orientation_z", msg->info.origin.orientation.z},
-        {"origin_orientation_w", msg->info.origin.orientation.w},
-        {"data", r_map}
+        {"width", OUTPUT_SIZE},
+        {"height", OUTPUT_SIZE},
+        {"resolution", OUTPUT_RES},
+        {"origin_position_x", 0.0}, // Local map, origin relative to car? Not quite.
+        // Actually, the client probably expects standard map origin logic.
+        // But since we are streaming a "live" view centered on the car, the origin changes every frame.
+        // If we say origin is (0,0), the client might draw it fixed.
+        // But the data is already rotated. 
+        // Let's provide 0s for origin and let the client just draw this image as a HUD element or centered map.
+        // Or we pass the car position? 
+        // For "crop the map around the car", usually it's for a minimap HUD.
+        {"origin_position_y", 0.0},
+        {"origin_position_z", 0.0},
+        {"origin_orientation_x", 0.0},
+        {"origin_orientation_y", 0.0},
+        {"origin_orientation_z", 0.0},
+        {"origin_orientation_w", 1.0},
+        {"data", rotated_map}
     };
 
     udp_sender_->send_json(map_info_msg.dump(), dest);

--- a/jetsonNano/ros2_ws/src/network_hmi/src/tcp_udp_bridge_node.cpp
+++ b/jetsonNano/ros2_ws/src/network_hmi/src/tcp_udp_bridge_node.cpp
@@ -94,9 +94,26 @@ TcpUdpBridgeNode::TcpUdpBridgeNode()
 TcpUdpBridgeNode::~TcpUdpBridgeNode()
 {
     RCLCPP_INFO(this->get_logger(), "Shutting down bridge node...");
-    // Stop threads in reverse order
-    tcp_server_->stop();
-    udp_receiver_->stop();
+
+    // Stop threads in reverse order with timing logs to diagnose hangs
+    {
+        auto t0 = std::chrono::steady_clock::now();
+        RCLCPP_INFO(this->get_logger(), "Stopping TcpControlServer...");
+        tcp_server_->stop();
+        auto t1 = std::chrono::steady_clock::now();
+        auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count();
+        RCLCPP_INFO(this->get_logger(), "TcpControlServer stopped (%.1f ms)", static_cast<double>(ms));
+    }
+
+    {
+        auto t0 = std::chrono::steady_clock::now();
+        RCLCPP_INFO(this->get_logger(), "Stopping UdpDataReceiver...");
+        udp_receiver_->stop();
+        auto t1 = std::chrono::steady_clock::now();
+        auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count();
+        RCLCPP_INFO(this->get_logger(), "UdpDataReceiver stopped (%.1f ms)", static_cast<double>(ms));
+    }
+
     // udp_sender_ and state objects are auto-destroyed
     RCLCPP_INFO(this->get_logger(), "Bridge node shut down complete.");
 }

--- a/jetsonNano/ros2_ws/src/network_hmi/src/udp_data_receiver.cpp
+++ b/jetsonNano/ros2_ws/src/network_hmi/src/udp_data_receiver.cpp
@@ -35,6 +35,7 @@ void UdpDataReceiver::start()
 
 void UdpDataReceiver::stop()
 {
+    RCLCPP_INFO(logger_, "UdpDataReceiver::stop() entry");
     running_ = false;
     if (data_socket_ != -1) {
         close(data_socket_); // This unblocks recvfrom()
@@ -43,6 +44,7 @@ void UdpDataReceiver::stop()
     if (thread_.joinable()) {
         thread_.join();
     }
+    RCLCPP_INFO(logger_, "UdpDataReceiver::stop() exit");
 }
 
 void UdpDataReceiver::receive_loop()
@@ -66,15 +68,28 @@ void UdpDataReceiver::receive_loop()
         return;
     }
 
+    // Set a receive timeout so recvfrom() wakes periodically and we can
+    // check `running_` to exit promptly during shutdown.
+    struct timeval tv;
+    tv.tv_sec = 1; // 1 second timeout
+    tv.tv_usec = 0;
+    setsockopt(data_socket_, SOL_SOCKET, SO_RCVTIMEO, (const char *)&tv, sizeof(tv));
+
     while (running_) {
         struct sockaddr_in cliaddr;
         socklen_t len = sizeof(cliaddr);
+        // Use no special flags; timeout is handled by SO_RCVTIMEO above.
         ssize_t n = recvfrom(
-            data_socket_, (char *)buffer, sizeof(buffer), MSG_WAITALL,
+            data_socket_, (char *)buffer, sizeof(buffer), 0,
             (struct sockaddr *)&cliaddr, &len);
         
         if (n <= 0) {
-            if (running_) { // Only log error if we weren't intentionally stopped
+            // Ignore benign timeout/interrupt errors (they happen regularly
+            // due to SO_RCVTIMEO) and only warn on real errors.
+            if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR) {
+                continue;
+            }
+            if (running_) { // Only log if we weren't intentionally stopped
                 RCLCPP_WARN(logger_, "UDP recvfrom error: %s", strerror(errno));
             }
             continue;

--- a/jetsonNano/ros2_ws/src/network_hmi/src/udp_data_receiver.cpp
+++ b/jetsonNano/ros2_ws/src/network_hmi/src/udp_data_receiver.cpp
@@ -35,7 +35,7 @@ void UdpDataReceiver::start()
 
 void UdpDataReceiver::stop()
 {
-    RCLCPP_INFO(logger_, "UdpDataReceiver::stop() entry");
+    //RCLCPP_INFO(logger_, "UdpDataReceiver::stop() entry");
     running_ = false;
     if (data_socket_ != -1) {
         close(data_socket_); // This unblocks recvfrom()
@@ -44,7 +44,7 @@ void UdpDataReceiver::stop()
     if (thread_.joinable()) {
         thread_.join();
     }
-    RCLCPP_INFO(logger_, "UdpDataReceiver::stop() exit");
+    //RCLCPP_INFO(logger_, "UdpDataReceiver::stop() exit");
 }
 
 void UdpDataReceiver::receive_loop()


### PR DESCRIPTION
This pull request improves the shutdown reliability and debuggability of the TCP and UDP network components, making server and receiver shutdowns more robust and easier to diagnose. The main changes enhance socket closure procedures, add detailed logging for shutdown and error handling, and make the UDP receiver more responsive to shutdown requests.

**TCP Server shutdown improvements:**
- Improved the shutdown process in `TcpControlServer::stop()` by first shutting down the listening socket to unblock `accept()`, then cleanly shutting down and closing all client sockets to promptly terminate client session threads. Entry and exit logs were added for better traceability.
- Enhanced `accept_loop()` to add debug logs before waiting for connections and improved error handling/logging when `accept()` fails, distinguishing between expected and unexpected errors during shutdown.

**UDP Receiver shutdown and responsiveness:**
- Added entry and exit logs to `UdpDataReceiver::stop()` for improved shutdown visibility. [[1]](diffhunk://#diff-bb6930381bc3bb24aca03114f770abd78ab2d0e0734b6888a490ce31a0147aefR38) [[2]](diffhunk://#diff-bb6930381bc3bb24aca03114f770abd78ab2d0e0734b6888a490ce31a0147aefR47)
- Set a receive timeout (`SO_RCVTIMEO`) on the UDP socket in `receive_loop()` to allow periodic checks of the running state, making shutdowns more responsive. Updated error handling to ignore benign timeout/interruption errors and only warn on real errors.

**Bridge node shutdown diagnostics:**
- Updated `TcpUdpBridgeNode` destructor to log timing information for stopping the TCP server and UDP receiver, helping diagnose potential shutdown hangs.